### PR TITLE
fix: Update Amplify build configuration for Next.js SSR

### DIFF
--- a/infra/modules/amplify/amplify.yml
+++ b/infra/modules/amplify/amplify.yml
@@ -9,9 +9,9 @@ frontend:
       commands:
         - npm run build
   artifacts:
-    # For Next.js 15 with static export
-    # Output is in frontend/out from repository root
-    baseDirectory: frontend/out
+    # For Next.js 15 with SSR/dynamic routes
+    # Output is in frontend/.next from repository root
+    baseDirectory: frontend/.next
     files:
       - '**/*'
   cache:


### PR DESCRIPTION
- Change artifacts baseDirectory from 'frontend/out' to 'frontend/.next'
- MyRSSPress uses dynamic routes ([id], [date]) which require SSR, not static export
- This fixes the Amplify build error: 'Artifact directory doesn't exist: frontend/out'

Root cause: Amplify was configured for static export but app uses dynamic routing that requires server-side rendering capabilities.

Fixes: Amplify deployment build failures