### PR TITLE
feat: Improve language selector with dropdown and flag emojis

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -112,27 +112,15 @@ export default function Home() {
                 {t.appTagline}
               </p>
             </div>
-            <div className="sm:absolute sm:right-0 flex gap-2">
-              <button
-                onClick={() => setLocale('ja')}
-                className={`px-4 py-2 min-h-[44px] text-sm font-serif font-bold border-2 border-black transition-colors ${
-                  locale === 'ja'
-                    ? 'bg-black text-white'
-                    : 'bg-white text-black hover:bg-gray-100'
-                }`}
+            <div className="sm:absolute sm:right-0">
+              <select
+                value={locale}
+                onChange={(e) => setLocale(e.target.value as Locale)}
+                className="px-4 py-2 min-h-[44px] text-sm font-serif font-bold border-2 border-black bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-black cursor-pointer"
               >
-                日本語
-              </button>
-              <button
-                onClick={() => setLocale('en')}
-                className={`px-4 py-2 min-h-[44px] text-sm font-serif font-bold border-2 border-black transition-colors ${
-                  locale === 'en'
-                    ? 'bg-black text-white'
-                    : 'bg-white text-black hover:bg-gray-100'
-                }`}
-              >
-                EN
-              </button>
+                <option value="en">🇺🇸 English</option>
+                <option value="ja">🇯🇵 日本語</option>
+              </select>
             </div>
           </div>
         </div>

--- a/frontend/components/features/home/LanguageFilter.tsx
+++ b/frontend/components/features/home/LanguageFilter.tsx
@@ -19,9 +19,9 @@ export default function LanguageFilter({
 }: LanguageFilterProps) {
 
   const languages = [
-    { value: 'ALL' as const, label: locale === 'ja' ? 'すべて' : 'All' },
-    { value: 'JP' as const, label: locale === 'ja' ? '日本語' : 'Japanese' },
-    { value: 'EN' as const, label: locale === 'ja' ? '英語' : 'English' },
+    { value: 'ALL' as const, label: locale === 'ja' ? 'すべて' : 'All Languages' },
+    { value: 'EN' as const, label: 'English' },
+    { value: 'JP' as const, label: '日本語' },
   ];
 
   return (

--- a/frontend/components/features/home/PopularNewspapers.tsx
+++ b/frontend/components/features/home/PopularNewspapers.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
-import LanguageFilter from './LanguageFilter';
 import SearchInput from './SearchInput';
 import SortFilter from './SortFilter';
 import type { NewspaperData, Locale } from '@/types';
@@ -25,6 +24,11 @@ export function PopularNewspapers({ locale, onNewspaperClick }: PopularNewspaper
     locale === 'ja' ? 'JP' : 'EN'
   );
   const [searchQuery, setSearchQuery] = useState('');
+
+  // Auto-sync language filter when locale changes
+  useEffect(() => {
+    setSelectedLanguage(locale === 'ja' ? 'JP' : 'EN');
+  }, [locale]);
 
   const fetchNewspapers = useCallback(async () => {
     setIsLoading(true);
@@ -108,11 +112,6 @@ export function PopularNewspapers({ locale, onNewspaperClick }: PopularNewspaper
           <SortFilter
             sortBy={sortBy}
             onSortChange={handleSortChange}
-            locale={locale}
-          />
-          <LanguageFilter
-            selectedLanguage={selectedLanguage}
-            onLanguageChange={setSelectedLanguage}
             locale={locale}
           />
           <SearchInput


### PR DESCRIPTION
## Summary
Improve language selector UX by changing to dropdown with flag emojis and auto-syncing Popular Newspapers language filter.

Fixes #67

## Changes

### 1. Header Language Selector
**Before**: Two separate buttons (日本語 / EN)  
**After**: Single dropdown with flag emojis

```typescript
<select>
  <option value="en">🇺🇸 English</option>
  <option value="ja">🇯🇵 日本語</option>
</select>
```

**Benefits**:
- More compact UI
- Clear visual indication with flag emojis
- Standard dropdown interaction pattern

### 2. Auto-sync Language Filter
When user changes language in header, Popular Newspapers automatically filters to that language:
- Header: 🇺🇸 English → Shows English newspapers
- Header: 🇯🇵 日本語 → Shows Japanese newspapers

**Implementation**:
```typescript
useEffect(() => {
  setSelectedLanguage(locale === 'ja' ? 'JP' : 'EN');
}, [locale]);
```

### 3. Hide Language Filter Dropdown
Removed the language filter dropdown from Popular Newspapers section since it's now controlled by the header selector.

**Before**: Sort filter + Language filter + Search  
**After**: Sort filter + Search

### 4. Consistent Labeling
- ✅ **English** (not "EN")
- ✅ **日本語** (not "Japanese")
- ✅ Flag emojis: 🇺🇸 🇯🇵

## User Experience

1. User selects "🇺🇸 English" in header
   - UI switches to English
   - Popular Newspapers automatically shows English newspapers
   - Cleaner interface with one less filter

2. User selects "🇯🇵 日本語" in header
   - UI switches to Japanese
   - Popular Newspapers automatically shows Japanese newspapers

## Test Results
- ✅ Language selector works correctly
- ✅ Popular Newspapers filter syncs with header
- ✅ Flag emojis display correctly
- ✅ No breaking changes

## Screenshots
**Header Language Selector**:
- Dropdown with flag emojis (🇺🇸 English / 🇯🇵 日本語)

**Popular Newspapers**:
- Language filter removed
- Auto-filters based on header selection

## Related
- Issue #67: https://github.com/kumagaias/my-rss-press/issues/67
- Language detection: `frontend/lib/i18n.ts`

## Checklist
- [x] Header language selector changed to dropdown
- [x] Flag emojis added (🇺🇸 🇯🇵)
- [x] Popular Newspapers language filter hidden
- [x] Auto-sync implemented
- [x] Consistent labeling (English / 日本語)
- [x] No breaking changes