### PR TITLE
fix: Restore date navigation on saved newspaper pages

### DIFF
--- a/frontend/app/newspaper/page.tsx
+++ b/frontend/app/newspaper/page.tsx
@@ -63,8 +63,16 @@ function NewspaperContent() {
     
     if (idParam) {
       setId(idParam);
-    }
-    if (dateParam) {
+      
+      // If no date parameter and it's a saved newspaper (not temp-*),
+      // set today's date as default
+      if (!dateParam && !idParam.startsWith('temp-')) {
+        const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
+        setDate(today);
+      } else if (dateParam) {
+        setDate(dateParam);
+      }
+    } else if (dateParam) {
       setDate(dateParam);
     }
     


### PR DESCRIPTION
## Summary
This PR fixes the missing date navigation on saved newspaper pages that was introduced in PR #70.

## Problem
After PR #70 was deployed, the date navigation component was not displayed on saved newspaper pages when accessed without a `date` parameter (e.g., `?id=xxx`).

## Root Cause
The date navigation is only shown when both conditions are met:
1. The newspaper is saved (not `temp-*`)
2. The `date` state variable is set

When accessing a saved newspaper with only `?id=xxx`, the `date` parameter was not set, causing the navigation to be hidden.

## Solution
Set today's date as the default when:
- An `id` parameter exists
- No `date` parameter is provided
- The newspaper is saved (not `temp-*`)

## Changes
- Modified query parameter parsing logic in `frontend/app/newspaper/page.tsx`
- Added default date assignment for saved newspapers without date parameter
- Date navigation now appears correctly on saved newspaper pages

## Testing
- ✅ All newspaper page tests passing (6/6)
- ✅ Date navigation displays on saved newspapers
- ✅ Users can navigate to historical newspapers
- ✅ No regression in existing functionality

## Related Issue
Fixes #73